### PR TITLE
Fix options overwrite between components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0
 
+ - BUGFIX: Fix corejs options overwrite between components. #50
+ - ENHANCEMENT: Rename to @sulu/web and restructure repository. #49
  - ENHANCEMENT: Add possibility to extend container link attributes. #48
  - BUGFIX: Fix menu button for chrome. #47
  - FEATURE: Add animation link hover scss mixin. #46

--- a/packages/core/core.js
+++ b/packages/core/core.js
@@ -115,7 +115,7 @@ var web = (function web() {
         // Instantiate object from base component and init it
         Component = web.getBaseComponent(name);
         instance = new Component();
-        instance.initialize(web.getElement(id), Object.assign(componentDefaultOptions[name], options));
+        instance.initialize(web.getElement(id), Object.assign({}, componentDefaultOptions[name], options));
 
         // Add component instance to registry
         componentInstances[id] = instance;


### PR DESCRIPTION
Object.assign need to be the first elemenet else it all get merged to the componentDefaultOptions and will.