### PR TITLE
Add a hint that for IE11 support object assign polyfill is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ npm install @sulu/web
 yarn add @sulu/web
 ```
 
+## IE Support
+
+To Support IE 11 you need a polyfill for `object.assign` function e.g.:
+
+```bash
+npm install core-js --save-dev
+```
+
+or
+
+```bash
+yarn install core-js --dev
+```
+
+and at the top of your main.js file require the polyfill:
+
+```js
+import 'core-js/features/object/assign';
+```
+
 ## Usage
 
 ### Create your first component


### PR DESCRIPTION
Object.assign seems not be supported by IE11 and currently I see no workaround without jquery for this. I personally would avoid to add the polyfill to this repository as not all user maybe need it.