### PR TITLE
Add timeago component

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "eslint-config-ma": "^1.0.1",
     "stylelint": "^9.2.1",
     "stylelint-config-ma": "^1.1.1"
+  },
+  "dependencies": {
+    "timeago.js": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,15 +25,13 @@
     "url": "https://github.com/sulu/web-js/issues"
   },
   "peerDependencies": {
-    "jquery": ">=1.7.2"
+    "jquery": ">=1.7.2",
+    "timeago.js": "^4.0.1"
   },
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-ma": "^1.0.1",
     "stylelint": "^9.2.1",
     "stylelint-config-ma": "^1.1.1"
-  },
-  "dependencies": {
-    "timeago.js": "^4.0.1"
   }
 }

--- a/packages/components/timeago/languageGerman.js
+++ b/packages/components/timeago/languageGerman.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var timeagoJS = require('timeago.js');
+
+/**
+ * Registers german locale for timeago component
+ */
+module.exports = function LanguageGerman() {
+    var locale = function(number, index) {
+        return [
+            ['gerade eben', 'genau jetzt'],
+            ['vor %s Sekunden', 'in %s Sekunden'],
+            ['vor einer Minute', 'in einer Minute'],
+            ['vor %s Minuten', 'in %s Minuten'],
+            ['vor einer Stunde', 'in einer Stunde'],
+            ['vor %s Stunden', 'in %s Stunden'],
+            ['vor einem Tag', 'in einem Tag'],
+            ['vor %s Tagen', 'in %s Tagen'],
+            ['vor einer Woche', 'in einer Woche'],
+            ['vor %s Wochen', 'in %s Wochen'],
+            ['vor einem Monat', 'in einem Monat'],
+            ['vor %s Monaten', 'in %s Monaten'],
+            ['vor einem Jahr', 'in einem Jahr'],
+            ['vor %s Jahren', 'in %s Jahren'],
+        ][index];
+    };
+
+    timeagoJS.register('de', locale);
+    timeagoJS.register('de_AT', locale);
+    timeagoJS.register('de_DE', locale);
+    timeagoJS.register('de_CH', locale);
+};

--- a/packages/components/timeago/languageGerman.js
+++ b/packages/components/timeago/languageGerman.js
@@ -26,7 +26,4 @@ module.exports = function LanguageGerman() {
     };
 
     timeagoJS.register('de', locale);
-    timeagoJS.register('de_AT', locale);
-    timeagoJS.register('de_DE', locale);
-    timeagoJS.register('de_CH', locale);
 };

--- a/packages/components/timeago/timeago.js
+++ b/packages/components/timeago/timeago.js
@@ -1,0 +1,27 @@
+// Relative time difference from date to now
+
+'use strict';
+
+var $ = require('jquery');
+var timeagoJS = require('timeago.js');
+
+module.exports = function Timeago() {
+    var timeago = {};
+
+    /**
+     * @param {HTMLElement} el
+     * @param {object} options
+     * @param {Date} options.date
+     * @param {string} [options.locale=en_US]
+     */
+    timeago.initialize = function initialize(el, options) {
+        var date = options.date;
+        var locale = options.locale || 'en_US';
+
+        $(el).html(timeagoJS.format(date, locale));
+    };
+
+    return {
+        initialize: timeago.initialize,
+    };
+};

--- a/packages/components/timeago/timeago.js
+++ b/packages/components/timeago/timeago.js
@@ -12,11 +12,10 @@ module.exports = function Timeago() {
      * @param {HTMLElement} el
      * @param {object} options
      * @param {Date} options.date
-     * @param {string} [options.locale=en_US]
      */
     timeago.initialize = function initialize(el, options) {
         var date = options.date;
-        var locale = options.locale || 'en_US';
+        var locale = document.documentElement.lang;
 
         $(el).html(timeagoJS.format(date, locale));
     };


### PR DESCRIPTION
This pull request adds a `timeago` component, which uses the library [timeago.js](https://timeago.org/).

English is used by default, but there is also support for additional locales.
There is a helper function which adds german language support. You have to import it from `@sulu/web/packages/components/timeago/languageGerman` and enable it by calling `languageGerman()`.
If you want to add more languages, have a look at the `languageGerman` function or in the official documentation of the library.

The `timeago` component accepts two options, `date` and `locale`. It will replace the content of the given `HTMLElement` with the relative time difference of `date` and the current time.