### PR TITLE
Add scroll direction component

### DIFF
--- a/packages/components/container-link/container-link.js
+++ b/packages/components/container-link/container-link.js
@@ -8,6 +8,20 @@ module.exports = function ContainerLink() {
     var containerLink = {};
 
     /**
+     * @example
+     * <div id="container-link" class="menu">
+     *    Lorem ipsum ...
+     *
+     *    <a href="#1">Link 1</a> <!-- Click on container will open this link -->
+     *    <a href="#2">Link 2</a>
+     * </div>
+     *
+     * import ContainerLink from '@sulu/web/packages/components/container-link';
+     * var component = new ContainerLink();
+     * component.initialize(document.getElementById('container-link'), {});
+     *
+     * @see scss/tools/container-link/_container-link.scss for css only solution
+     *
      * @param {HTMLElement} el
      */
     containerLink.initialize = function initialize(el) {

--- a/packages/components/container-link/container-link.js
+++ b/packages/components/container-link/container-link.js
@@ -56,7 +56,7 @@ module.exports = function ContainerLink() {
     };
 
     return {
-        initialize: containerLink.initialize
+        initialize: containerLink.initialize,
     };
 };
 

--- a/packages/components/expand/expand.js
+++ b/packages/components/expand/expand.js
@@ -68,6 +68,6 @@ module.exports = function Expand() {
     };
 
     return {
-        initialize: expand.initialize
+        initialize: expand.initialize,
     };
 };

--- a/packages/components/expand/expand.js
+++ b/packages/components/expand/expand.js
@@ -8,6 +8,19 @@ module.exports = function Expand() {
     var expand = {};
 
     /**
+     * @example
+     * <button id="expand" class="button">
+     *    Lorem ipsum ...
+     * </button>
+     *
+     * <div id="expand-container" class="container">
+     *     Container
+     * </div>
+     *
+     * import Expand from '@sulu/web/packages/components/expand';
+     * var component = new Expand();
+     * component.initialize(document.getElementById('expand'), {});
+     *
      * @param {HTMLElement} el
      * @param {object} options
      */

--- a/packages/components/scroll-direction/scroll-direction.js
+++ b/packages/components/scroll-direction/scroll-direction.js
@@ -1,0 +1,66 @@
+// Scroll direction component
+
+'use strict';
+
+module.exports = function ScrollDirection() {
+    var scrollDirection = {};
+
+    /**
+     * @param {HTMLElement} el
+     * @param {object} options
+     */
+    scrollDirection.initialize = function initialize(el, options) {
+        scrollDirection.direction = null;
+        scrollDirection.offset = 0;
+        scrollDirection.upClass = options.upClass
+            ? options.upClass
+            : el.className.split(' ')[0] + '--scroll-up';
+        scrollDirection.downClass = options.downClass
+            ? options.downClass
+            : el.className.split(' ')[0] + '--scroll-down';
+        window.addEventListener(
+            'scroll',
+            scrollDirection.checkPosition.bind(this, el),
+            {
+                passive: true
+            }
+        );
+        scrollDirection.checkPosition(el);
+    };
+
+    /**
+     * @param {HTMLElement} el
+     */
+    scrollDirection.checkPosition = function(el) {
+        var direction = 'up';
+
+        if (window.pageYOffset > scrollDirection.offset) {
+            direction = 'down';
+        }
+
+        scrollDirection.offset = window.pageYOffset;
+        if (0 >= window.pageYOffset) {
+            scrollDirection.direction = null;
+            el.classList.remove(scrollDirection.upClass);
+            el.classList.remove(scrollDirection.downClass);
+
+            return;
+        }
+
+        if (scrollDirection.direction === direction) {
+            return;
+        }
+
+        if ('down' === direction) {
+            el.classList.remove(scrollDirection.upClass);
+            el.classList.add(scrollDirection.downClass);
+        } else {
+            el.classList.remove(scrollDirection.downClass);
+            el.classList.add(scrollDirection.upClass);
+        }
+    };
+
+    return {
+        initialize: scrollDirection.initialize
+    };
+};

--- a/packages/components/scroll-direction/scroll-direction.js
+++ b/packages/components/scroll-direction/scroll-direction.js
@@ -6,6 +6,15 @@ module.exports = function ScrollDirection() {
     var scrollDirection = {};
 
     /**
+     * @example
+     * <div id="scroll-direction" class="menu">
+     *    Lorem ipsum ...
+     * </div>
+     *
+     * import ScrollDirection from '@sulu/web/packages/components/scroll-direction';
+     * var component = new ScrollDirection();
+     * component.initialize(document.getElementById('scroll-direction'), {});
+     *
      * @param {HTMLElement} el
      * @param {object} options
      */

--- a/packages/components/scroll-direction/scroll-direction.js
+++ b/packages/components/scroll-direction/scroll-direction.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+var passiveEvents = require('../services/passive-events');
+
 module.exports = function ScrollDirection() {
     var scrollDirection = {};
 
@@ -30,7 +32,7 @@ module.exports = function ScrollDirection() {
         window.addEventListener(
             'scroll',
             scrollDirection.checkPosition.bind(this, el),
-            options.passive ? {
+            passiveEvents ? {
                 passive: true,
             } : false
         );

--- a/packages/components/scroll-direction/scroll-direction.js
+++ b/packages/components/scroll-direction/scroll-direction.js
@@ -30,9 +30,9 @@ module.exports = function ScrollDirection() {
         window.addEventListener(
             'scroll',
             scrollDirection.checkPosition.bind(this, el),
-            {
+            options.passive ? {
                 passive: true,
-            }
+            } : false
         );
         scrollDirection.checkPosition(el);
     };

--- a/packages/components/scroll-direction/scroll-direction.js
+++ b/packages/components/scroll-direction/scroll-direction.js
@@ -31,7 +31,7 @@ module.exports = function ScrollDirection() {
             'scroll',
             scrollDirection.checkPosition.bind(this, el),
             {
-                passive: true
+                passive: true,
             }
         );
         scrollDirection.checkPosition(el);
@@ -70,6 +70,6 @@ module.exports = function ScrollDirection() {
     };
 
     return {
-        initialize: scrollDirection.initialize
+        initialize: scrollDirection.initialize,
     };
 };

--- a/packages/components/truncate/truncate.js
+++ b/packages/components/truncate/truncate.js
@@ -14,8 +14,9 @@ module.exports = function Truncate() {
      *    Lorem ipsum ...
      * </div>
      *
-     * import truncate from '@sulu/web/packages/components/truncate';
-     * truncate.initialize($('#truncate'), {});
+     * import Truncate from '@sulu/web/packages/components/truncate';
+     * var component = new Truncate();
+     * component.initialize(document.getElementById('truncate'), {});
      *
      * @param {HTMLElement} el
      * @param {object} options

--- a/packages/components/truncate/truncate.js
+++ b/packages/components/truncate/truncate.js
@@ -67,6 +67,6 @@ module.exports = function Truncate() {
     };
 
     return {
-        initialize: truncate.initialize
+        initialize: truncate.initialize,
     };
 };

--- a/packages/components/window-scroll/window-scroll.js
+++ b/packages/components/window-scroll/window-scroll.js
@@ -25,9 +25,9 @@ module.exports = function WindowScroll() {
         window.addEventListener(
             'scroll',
             windowScroll.checkPosition.bind(this, el),
-            {
+            options.passive ? {
                 passive: true,
-            }
+            } : false
         );
         windowScroll.checkPosition(el);
     };

--- a/packages/components/window-scroll/window-scroll.js
+++ b/packages/components/window-scroll/window-scroll.js
@@ -2,10 +2,12 @@
 
 'use strict';
 
+var passiveEvents = require('../services/passive-events');
+
 module.exports = function WindowScroll() {
     var windowScroll = {};
 
-    /*
+    /**
      * @example
      * <div id="window-scroll" class="Menu">
      *    Lorem ipsum ...
@@ -25,7 +27,7 @@ module.exports = function WindowScroll() {
         window.addEventListener(
             'scroll',
             windowScroll.checkPosition.bind(this, el),
-            options.passive ? {
+            passiveEvents ? {
                 passive: true,
             } : false
         );

--- a/packages/components/window-scroll/window-scroll.js
+++ b/packages/components/window-scroll/window-scroll.js
@@ -26,7 +26,7 @@ module.exports = function WindowScroll() {
             'scroll',
             windowScroll.checkPosition.bind(this, el),
             {
-                passive: true
+                passive: true,
             }
         );
         windowScroll.checkPosition(el);
@@ -49,6 +49,6 @@ module.exports = function WindowScroll() {
     };
 
     return {
-        initialize: windowScroll.initialize
+        initialize: windowScroll.initialize,
     };
 };

--- a/packages/components/window-scroll/window-scroll.js
+++ b/packages/components/window-scroll/window-scroll.js
@@ -13,7 +13,13 @@ module.exports = function WindowScroll() {
         windowScroll.isTop = true;
         windowScroll.offset = options.offset ? options.offset : 0;
         windowScroll.toggleClass = el.className.split(' ')[0] + '--scroll';
-        window.addEventListener('scroll', windowScroll.checkPosition.bind(this, el));
+        window.addEventListener(
+            'scroll',
+            windowScroll.checkPosition.bind(this, el),
+            {
+                passive: true
+            }
+        );
         windowScroll.checkPosition(el);
     };
 

--- a/packages/components/window-scroll/window-scroll.js
+++ b/packages/components/window-scroll/window-scroll.js
@@ -5,7 +5,16 @@
 module.exports = function WindowScroll() {
     var windowScroll = {};
 
-    /**
+    /*
+     * @example
+     * <div id="window-scroll" class="Menu">
+     *    Lorem ipsum ...
+     * </div>
+     *
+     * import WindowScroll from '@sulu/web/packages/components/window-scroll';
+     * var component = new WindowScroll();
+     * component.initialize(document.getElementById('window-scroll'), {});
+     *
      * @param {HTMLElement} el
      * @param {object} options
      */

--- a/packages/core/core.js
+++ b/packages/core/core.js
@@ -286,7 +286,7 @@ var web = (function web() {
         getComponent: web.getComponent,
         hasComponent: web.hasComponent,
         hasService: web.hasService,
-        removeComponent: web.removeComponent
+        removeComponent: web.removeComponent,
     };
 })();
 

--- a/packages/experimental/lazy/lazy.js
+++ b/packages/experimental/lazy/lazy.js
@@ -15,7 +15,7 @@ var lazy = (function lazy() {
         componentRegistry: {},
         serviceRegistry: {},
         deferredComponents: {},
-        deferredServices: {}
+        deferredServices: {},
     };
 
     /**
@@ -130,7 +130,7 @@ var lazy = (function lazy() {
         registerComponent: lazy.registerComponent,
         registerService: lazy.registerService,
         startComponents: lazy.startComponents,
-        startServices: lazy.startServices
+        startServices: lazy.startServices,
     };
 })();
 

--- a/packages/services/api/api.js
+++ b/packages/services/api/api.js
@@ -20,7 +20,7 @@ var Api = (function() {
             dataType: 'json',
             url: uri,
             method: method,
-            data: data
+            data: data,
         });
     };
 

--- a/packages/services/google-map-library/google-map-library.js
+++ b/packages/services/google-map-library/google-map-library.js
@@ -7,7 +7,7 @@ var $ = require('jquery');
 var GoogleMapLibrary = (function() {
     var googleMapLibrary = {
         key: '',
-        promise: null
+        promise: null,
     };
 
     /**

--- a/packages/services/passive-events/passive-events.js
+++ b/packages/services/passive-events/passive-events.js
@@ -1,0 +1,18 @@
+// Detect if the current browser does support passive event listeners
+// Inspired by: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+var supportsPassive = false;
+
+try {
+    // eslint-disable-next-line vars-on-top
+    var opts = Object.defineProperty({}, 'passive', {
+        get: function() {
+            supportsPassive = true;
+        },
+    });
+    window.addEventListener('testPassive', null, opts);
+    window.removeEventListener('testPassive', null, opts);
+} catch (e) {
+    // Catch all errors in the code above
+}
+
+module.exports = supportsPassive;


### PR DESCRIPTION
The scroll direction component will add based on the scroll direction class a `--scroll-down` or `--scroll-down` modifier to the class. It can be used easily for menu as in the top position the modifiers classes are removed so you can show a big menu when scroll position is top, no menu when you did scroll down and a small menu when the user did scroll up a little bit.

The difference to the [window-scroll](https://github.com/sulu/web-js/pull/45) component is that the window scroll component has only 2 states (top, scrolled) and scroll direction has 3 states (top, scrolled down, scrolled up).


Example usage: https://jsfiddle.net/f0p4eha5/

![scroll-direction](https://user-images.githubusercontent.com/1698337/86851894-08a68b00-c0b4-11ea-834f-d88cc7e9357f.gif)
