### PR TITLE
Fix passive events path

### DIFF
--- a/packages/components/window-scroll/window-scroll.js
+++ b/packages/components/window-scroll/window-scroll.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var passiveEvents = require('../services/passive-events');
+var passiveEvents = require('../../services/passive-events/passive-events');
 
 module.exports = function WindowScroll() {
     var windowScroll = {};


### PR DESCRIPTION
Fix the bug that appears when running `npm install` : 

```
ERROR in ./node_modules/@sulu/web/packages/components/window-scroll/window-scroll.js
Module not found: Error: Can't resolve '../services/passive-events' in '/home/quentin/PROJETS/project_name/assets/website/node_modules/@sulu/web/packages/components/window-scroll'
 @ ./node_modules/@sulu/web/packages/components/window-scroll/window-scroll.js 4:20-57
 @ ./js/main.js
```