### PR TITLE
Fix Truncate component on window load

### DIFF
--- a/packages/components/truncate/truncate.js
+++ b/packages/components/truncate/truncate.js
@@ -35,7 +35,7 @@ module.exports = function Truncate() {
         truncate.calculateRegex();
         truncate.calculateText();
 
-        $(window).on('resize', debounce(truncate.calculateText, truncate.debounceDelay));
+        $(window).on('load resize', debounce(truncate.calculateText, truncate.debounceDelay));
     };
 
     /**


### PR DESCRIPTION
The truncate component does not always calculate correctly since sometimes we need to wait for the JS to load to get correct font position/size/... This PR adds a trigger on load to prevent these issues.